### PR TITLE
incorrect test_csv in web version

### DIFF
--- a/ml/cc/exercises/intro_to_ml_fairness.ipynb
+++ b/ml/cc/exercises/intro_to_ml_fairness.ipynb
@@ -248,7 +248,7 @@
         "\n",
         "train_csv = tf.keras.utils.get_file('adult.data', \n",
         "  'https://download.mlcc.google.com/mledu-datasets/adult_census_train.csv')\n",
-        "test_csv = tf.keras.utils.get_file('adult.test', \n",
+        "test_csv = tf.keras.utils.get_file('adult.test' , \n",
         "  'https://download.mlcc.google.com/mledu-datasets/adult_census_test.csv')\n",
         "\n",
         "train_df = pd.read_csv(train_csv, names=COLUMNS, sep=r'\\s*,\\s*', \n",


### PR DESCRIPTION
The code here in github is correct, but the code published in the web is not
https://colab.research.google.com/github/google/eng-edu/blob/master/ml/cc/exercises/intro_to_ml_fairness.ipynb#scrollTo=-xgIRapb5LaQ
test_csv = .... adult.data
should be adult.test
![image](https://user-images.githubusercontent.com/130455/102726553-937ee900-42d4-11eb-9766-4be5c3bb5c0c.png)
